### PR TITLE
Fix request bluetooth permission on startup for iOS

### DIFF
--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   FlutterEventChannel* stateChannel = [FlutterEventChannel eventChannelWithName:NAMESPACE @"/state" binaryMessenger:[registrar messenger]];
   FlutterBluePlugin* instance = [[FlutterBluePlugin alloc] init];
   instance.channel = channel;
-  instance.centralManager = [[CBCentralManager alloc] initWithDelegate:instance queue:nil];
   instance.scannedPeripherals = [NSMutableDictionary new];
   instance.servicesThatNeedDiscovered = [NSMutableArray new];
   instance.characteristicsThatNeedDiscovered = [NSMutableArray new];
@@ -63,6 +62,9 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if (self.centralManager == nil) {
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+  }
   if ([@"setLogLevel" isEqualToString:call.method]) {
     NSNumber *logLevelIndex = [call arguments];
     _logLevel = (LogLevel)[logLevelIndex integerValue];

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -62,14 +62,16 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if (self.centralManager == nil) {
-    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
-  }
   if ([@"setLogLevel" isEqualToString:call.method]) {
     NSNumber *logLevelIndex = [call arguments];
     _logLevel = (LogLevel)[logLevelIndex integerValue];
     result(nil);
-  } else if ([@"state" isEqualToString:call.method]) {
+    return;
+  }
+  if (self.centralManager == nil) {
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+  }
+  if ([@"state" isEqualToString:call.method]) {
     FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self->_centralManager.state]];
     result(data);
   } else if([@"isAvailable" isEqualToString:call.method]) {

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -74,10 +74,8 @@ class FlutterBlue {
   }
 
   _setLogLevelIfAvailable() async {
-    if (await isAvailable) {
-      // Send the log level to the underlying platforms.
-      setLogLevel(logLevel);
-    }
+    // Send the log level to the underlying platforms.
+    setLogLevel(logLevel);
   }
 
   /// Starts a scan for Bluetooth Low Energy devices and returns a stream


### PR DESCRIPTION
https://github.com/pauldemarco/flutter_blue/pull/964

PR https://github.com/pauldemarco/flutter_blue/pull/599 delays centralManager initialization, but instantiating FlutterBlue in flutter calls into _setLogLevelIfAvailable() which calls into isAvailable and triggers a popup anyway.
This PR skips isAvailable call in the FlutterBlue constructor and allows setting of log level without initializing centralManager.
The side effect of this change is, for some reason, Bluetooth permission always returns "denied" until centralManager is initialized. Similarly, Bluetooth permission under App Settings does not appear until centralManager is initialized.